### PR TITLE
feat: allow signing versioned transaction from pre-computed signature

### DIFF
--- a/src/main/kotlin/org/sol4k/Transaction.kt
+++ b/src/main/kotlin/org/sol4k/Transaction.kt
@@ -26,7 +26,7 @@ class Transaction(
         signatures.add(Base58.encode(signature))
     }
 
-    private fun addSignature(signature: String) {
+    fun addSignature(signature: String) {
         signatures.add(signature)
     }
 

--- a/src/main/kotlin/org/sol4k/VersionedTransaction.kt
+++ b/src/main/kotlin/org/sol4k/VersionedTransaction.kt
@@ -20,11 +20,16 @@ class VersionedTransaction private constructor(
     fun sign(keypair: Keypair) {
         val data = message.serialize()
         val signature = keypair.sign(data)
-        addSignature(signature)
+        addSignature(signature, data)
     }
 
-    fun addSignature(signature: ByteArray) {
-        val data = message.serialize()
+    fun addSignature(signature: String) {
+        val signatureBytes = Base58.decode(signature)
+        addSignature(signatureBytes)
+    }
+
+    private fun addSignature(signature: ByteArray, serializedMessage: ByteArray? = null) {
+        val data = serializedMessage ?: message.serialize()
 
         for (i in 0 until message.header.numRequireSignatures) {
             val a = message.accounts[i]

--- a/src/main/kotlin/org/sol4k/VersionedTransaction.kt
+++ b/src/main/kotlin/org/sol4k/VersionedTransaction.kt
@@ -20,11 +20,11 @@ class VersionedTransaction private constructor(
     fun sign(keypair: Keypair) {
         val data = message.serialize()
         val signature = keypair.sign(data)
-        sign(signature, data)
+        addSignature(signature)
     }
 
-    fun sign(signature: ByteArray, serializedMessage: ByteArray? = null) {
-        val data = serializedMessage ?: message.serialize()
+    fun addSignature(signature: ByteArray) {
+        val data = message.serialize()
 
         for (i in 0 until message.header.numRequireSignatures) {
             val a = message.accounts[i]

--- a/src/main/kotlin/org/sol4k/VersionedTransaction.kt
+++ b/src/main/kotlin/org/sol4k/VersionedTransaction.kt
@@ -20,6 +20,12 @@ class VersionedTransaction private constructor(
     fun sign(keypair: Keypair) {
         val data = message.serialize()
         val signature = keypair.sign(data)
+        sign(signature, data)
+    }
+
+    fun sign(signature: ByteArray, serializedMessage: ByteArray? = null) {
+        val data = serializedMessage ?: message.serialize()
+
         for (i in 0 until message.header.numRequireSignatures) {
             val a = message.accounts[i]
             if (a.verify(signature, data)) {

--- a/src/test/kotlin/org/sol4k/VersionedTransactionTest.kt
+++ b/src/test/kotlin/org/sol4k/VersionedTransactionTest.kt
@@ -104,8 +104,8 @@ class VersionedTransactionTest {
 
         // assume no private key is exposed, only the final signature is provided
         val data = message.serialize()
-        val sig1 = signer1.sign(data)
-        val sig2 = signer2.sign(data)
+        val sig1 = Base58.encode(signer1.sign(data))
+        val sig2 = Base58.encode(signer2.sign(data))
 
         transaction1.addSignature(sig1)
         transaction1.addSignature(sig2)

--- a/src/test/kotlin/org/sol4k/VersionedTransactionTest.kt
+++ b/src/test/kotlin/org/sol4k/VersionedTransactionTest.kt
@@ -107,8 +107,8 @@ class VersionedTransactionTest {
         val sig1 = signer1.sign(data)
         val sig2 = signer2.sign(data)
 
-        transaction1.sign(sig1)
-        transaction1.sign(sig2)
+        transaction1.addSignature(sig1)
+        transaction1.addSignature(sig2)
 
         val signatures = transaction1.signatures
         assertEquals(2, signatures.size)

--- a/src/test/kotlin/org/sol4k/VersionedTransactionTest.kt
+++ b/src/test/kotlin/org/sol4k/VersionedTransactionTest.kt
@@ -120,6 +120,6 @@ class VersionedTransactionTest {
         transaction2.sign(signer1)
         transaction2.sign(signer2)
 
-        assertEquals(transaction1, transaction2)
+        assertTrue(transaction1.serialize().contentEquals(transaction2.serialize()))
     }
 }


### PR DESCRIPTION
this PR adds a function `sign(ByteArray)` that allows adding a pre-computed signature to a `VersionedTransaction`. 

it will now be possible to sign a `VersionedTransaction` without needing explicit access to the signer's Keypair, enabling offline signing.