### PR TITLE
fix: add fee payer key meta for non-participating fee payer

### DIFF
--- a/src/main/kotlin/org/sol4k/TransactionMessage.kt
+++ b/src/main/kotlin/org/sol4k/TransactionMessage.kt
@@ -322,7 +322,10 @@ data class TransactionMessage internal constructor(
             feePayer: PublicKey,
             instructions: List<Instruction>,
         ): CompileKeys {
-            val m = mutableMapOf<PublicKey, CompileKeyMeta>()
+            val m = mutableMapOf<PublicKey, CompileKeyMeta>(
+                feePayer to CompileKeyMeta(signer = true, writable = true, invoked = false)
+            )
+
             instructions.forEach { instruction ->
                 // compile program
                 var v = m[instruction.programId]

--- a/src/main/kotlin/org/sol4k/TransactionMessage.kt
+++ b/src/main/kotlin/org/sol4k/TransactionMessage.kt
@@ -323,7 +323,7 @@ data class TransactionMessage internal constructor(
             instructions: List<Instruction>,
         ): CompileKeys {
             val m = mutableMapOf<PublicKey, CompileKeyMeta>(
-                feePayer to CompileKeyMeta(signer = true, writable = true, invoked = false)
+                feePayer to CompileKeyMeta(signer = true, writable = true, invoked = false),
             )
 
             instructions.forEach { instruction ->

--- a/src/test/kotlin/org/sol4k/TransactionMessageTest.kt
+++ b/src/test/kotlin/org/sol4k/TransactionMessageTest.kt
@@ -44,6 +44,50 @@ class TransactionMessageTest {
     }
 
     @Test
+    fun shouldCreateNewMessageWithNonParticipatingFeePayer() {
+        val expectedMessage = TransactionMessage(
+            version = V0,
+            header = MessageHeader(
+                numRequireSignatures = 2,
+                numReadonlySignedAccounts = 0,
+                numReadonlyUnsignedAccounts = 1,
+            ),
+            accounts = listOf(
+                feePayerPublicKey(),
+                PublicKey("87jPsvNeMH1RcZvwM9Y5z5Ffo3QDsuKUWzAcmzzFG1oa"),
+                PublicKey("A4iUVr5KjmsLymUcv4eSKPedUtoaBceiPeGipKMYc69b"),
+                SYSTEM_PROGRAM,
+            ),
+            recentBlockhash = "FwRYtTPRk5N4wUeP87rTw9kQVSwigB6kbikGzzeCMrW5",
+            instructions = listOf(
+                CompiledInstruction(
+                    programIdIndex = 3,
+                    accounts = listOf(1, 2),
+                    data = data(),
+                ),
+            ),
+            addressLookupTables = emptyList(),
+        )
+
+        val message = TransactionMessage.newMessage(
+            feePayer = feePayerPublicKey(),
+            recentBlockhash = "FwRYtTPRk5N4wUeP87rTw9kQVSwigB6kbikGzzeCMrW5",
+            instructions = listOf(
+                BaseInstruction(
+                    programId = SYSTEM_PROGRAM,
+                    keys = listOf(
+                        AccountMeta.signerAndWritable(PublicKey("87jPsvNeMH1RcZvwM9Y5z5Ffo3QDsuKUWzAcmzzFG1oa")),
+                        AccountMeta.writable(PublicKey("A4iUVr5KjmsLymUcv4eSKPedUtoaBceiPeGipKMYc69b")),
+                    ),
+                    data = data(),
+                ),
+            ),
+        )
+
+        assertEquals(message, expectedMessage)
+    }
+
+    @Test
     fun shouldCreateNewMessageGivenEmptyAddressesInAddressLookupTables() {
         val expectedMessage = TransactionMessage(
             version = V0,


### PR DESCRIPTION
fixes #141

when creating a new `TransactionMessage`, the `feePayer`'s public key is now added to `m: mutableMapOf<PublicKey, CompileKeyMeta>` at the beginning of the `newCompileKeys` call

this enables creating transaction messages with a non-participating fee payer, as shown in the provided unit test