### PR TITLE
Make RPC transport configurable and add support for custom headers

### DIFF
--- a/src/main/kotlin/org/sol4k/Connection.kt
+++ b/src/main/kotlin/org/sol4k/Connection.kt
@@ -39,22 +39,24 @@ import org.sol4k.rpc.SimulateTransactionResponse
 import org.sol4k.rpc.TokenAmount
 import org.sol4k.rpc.TokenBalanceResult
 import org.sol4k.rpc.VersionResult
-import java.io.BufferedReader
-import java.io.InputStreamReader
+import org.sol4k.transport.HttpUrlConnectionTransport
+import org.sol4k.transport.RpcTransport
 import java.math.BigInteger
-import java.net.HttpURLConnection
-import java.net.URL
 import java.util.Base64
 
 class Connection @JvmOverloads constructor(
     private val rpcUrl: String,
     private val commitment: Commitment = FINALIZED,
+    private val transport: RpcTransport = HttpUrlConnectionTransport(),
+    private val headers: Map<String, String> = emptyMap(),
 ) {
     @JvmOverloads
     constructor(
         rpcUrl: RpcUrl,
         commitment: Commitment = FINALIZED,
-    ) : this(rpcUrl.value, commitment)
+        transport: RpcTransport = HttpUrlConnectionTransport(),
+        headers: Map<String, String> = emptyMap(),
+    ) : this(rpcUrl.value, commitment, transport, headers)
 
     private val jsonParser = Json {
         ignoreUnknownKeys = true
@@ -315,22 +317,12 @@ class Connection @JvmOverloads constructor(
     }
 
     private inline fun <reified T, reified I : Any> rpcCall(method: String, params: List<I>): T {
-        val connection = URL(rpcUrl).openConnection() as HttpURLConnection
-        connection.requestMethod = "POST"
-        connection.setRequestProperty("Content-Type", "application/json")
-        connection.doOutput = true
-        connection.outputStream.use {
-            val body = Json.encodeToString(
-                RpcRequest(method, params),
-            )
-            it.write(body.toByteArray())
-        }
-        val responseBody = connection.inputStream.use {
-            BufferedReader(InputStreamReader(it)).use { reader ->
-                reader.readText()
-            }
-        }
-        connection.disconnect()
+        val body = Json.encodeToString(
+            RpcRequest(method, params),
+        )
+
+        val responseBody = transport.post(rpcUrl, body, headers)
+
         try {
             val (result) = jsonParser.decodeFromString<RpcResponse<T>>(responseBody)
             return result

--- a/src/main/kotlin/org/sol4k/transport/HttpUrlConnectionTransport.kt
+++ b/src/main/kotlin/org/sol4k/transport/HttpUrlConnectionTransport.kt
@@ -1,0 +1,38 @@
+package org.sol4k.transport
+
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
+
+class HttpUrlConnectionTransport : RpcTransport {
+
+    override fun post(
+        url: String,
+        body: String,
+        headers: Map<String, String>,
+    ): String {
+        val connection = URL(url).openConnection() as HttpURLConnection
+        connection.requestMethod = "POST"
+
+        connection.setRequestProperty("Content-Type", "application/json")
+        headers.forEach { (key, value) ->
+            connection.setRequestProperty(key, value)
+        }
+
+        connection.doOutput = true
+
+        connection.outputStream.use {
+            it.write(body.toByteArray())
+        }
+
+        val responseBody = connection.inputStream.use {
+            BufferedReader(InputStreamReader(it)).use { reader ->
+                reader.readText()
+            }
+        }
+
+        connection.disconnect()
+        return responseBody
+    }
+}

--- a/src/main/kotlin/org/sol4k/transport/RpcTransport.kt
+++ b/src/main/kotlin/org/sol4k/transport/RpcTransport.kt
@@ -1,0 +1,10 @@
+package org.sol4k.transport
+
+interface RpcTransport {
+
+    fun post(
+        url: String,
+        body: String,
+        headers: Map<String, String> = emptyMap(),
+    ): String
+}

--- a/src/test/kotlin/org/sol4k/ConnectionTransportTest.kt
+++ b/src/test/kotlin/org/sol4k/ConnectionTransportTest.kt
@@ -1,0 +1,79 @@
+package org.sol4k
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Test
+import org.sol4k.api.Health
+import org.sol4k.transport.RpcTransport
+import kotlin.test.assertEquals
+
+internal class ConnectionTransportTest {
+
+    @Test
+    fun shouldUseInjectedTransportAndForwardHeaders() {
+        val transport = CapturingTransport()
+        val headers = mapOf(
+            "x-api-key" to "test-api-key",
+            "x-client" to "sol4k-test",
+        )
+        val connection = Connection(
+            "https://example.solana.rpc",
+            transport = transport,
+            headers = headers,
+        )
+
+        val health = connection.getHealth()
+
+        assertEquals(Health.OK, health)
+        assertEquals(1, transport.callCount)
+        assertEquals("https://example.solana.rpc", transport.url)
+        assertEquals(headers, transport.headers)
+
+        val request = Json.parseToJsonElement(transport.body).jsonObject
+        assertEquals("getHealth", request["method"]?.jsonPrimitive?.content)
+        assertEquals("2.0", request["jsonrpc"]?.jsonPrimitive?.content)
+        assertEquals(0, request["params"]?.jsonArray?.size)
+    }
+
+    @Test
+    fun shouldUseInjectedTransportWithRpcUrlConstructor() {
+        val transport = CapturingTransport()
+        val headers = mapOf("Authorization" to "Bearer test-token")
+        val connection = Connection(
+            RpcUrl.DEVNET,
+            transport = transport,
+            headers = headers,
+        )
+
+        val health = connection.getHealth()
+
+        assertEquals(Health.OK, health)
+        assertEquals(1, transport.callCount)
+        assertEquals(RpcUrl.DEVNET.value, transport.url)
+        assertEquals(headers, transport.headers)
+    }
+
+    private class CapturingTransport : RpcTransport {
+        lateinit var url: String
+        lateinit var body: String
+        lateinit var headers: Map<String, String>
+        var callCount = 0
+
+        override fun post(
+            url: String,
+            body: String,
+            headers: Map<String, String>,
+        ): String {
+            this.url = url
+            this.body = body
+            this.headers = headers
+            callCount++
+
+            return """
+                {"result":"ok","id":1,"jsonrpc":"2.0"}
+            """.trimIndent()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces a configurable RPC transport layer and support for custom HTTP headers in `Connection`.

It enables using custom RPC providers (e.g. Tatum, QuickNode, Helius) that require authentication headers or custom HTTP clients.

---

## Motivation

Currently, `Connection` uses `HttpURLConnection` internally and does not allow:

* adding custom HTTP headers (e.g. API keys)
* using a custom HTTP client (e.g. OkHttp)
* customizing networking behavior (timeouts, retries, logging)

This makes it difficult to use many third-party RPC providers.

---

## Changes

* Introduced `RpcTransport` interface
* Added default implementation: `HttpUrlConnectionTransport`
* Updated `Connection` to accept:

  * `transport: RpcTransport`
  * `headers: Map<String, String>`
* Refactored internal `rpcCall` to use transport instead of hardcoded `HttpURLConnection`

---

## Backward compatibility

✅ No breaking changes

* Existing constructors still work as before
* Default behavior remains unchanged

---

## Example usage

### Default usage (unchanged)

```kotlin
val connection = Connection(RpcUrl.MAINNET)
```

### Custom RPC with headers

```kotlin
val connection = Connection(
    rpcUrl = "https://solana-mainnet.gateway.tatum.io",
    headers = mapOf("x-api-key" to "YOUR_API_KEY")
)
```

### Custom transport (e.g. OkHttp)

```kotlin
val connection = Connection(
    rpcUrl = "...",
    transport = OkHttpRpcTransport(...)
)
```

---

## Why this approach?

* Keeps existing API intact
* Introduces minimal abstraction (`RpcTransport`)
* Allows future extensions (OkHttp, Ktor, retries, logging, etc.)
* Avoids coupling `Connection` to a specific HTTP client

---

## Notes

This change enables integration with modern RPC providers that require authentication and improves flexibility of the networking layer.
