### PR TITLE
Add connect/read timeouts to Connection

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -145,6 +145,19 @@ val blockhash = connection.getLatestBlockhash()
 val finalizedBlockhash = connection.getLatestBlockhash(Commitment.FINALIZED)
 ```
 
+Every RPC call is bounded by connect and read timeouts so a slow or unresponsive
+node cannot block the calling thread indefinitely. They default to 15s (connect)
+and 30s (read) and can be overridden, in milliseconds, when creating a connection.
+
+```kotlin
+val connection = Connection(
+    RpcUrl.DEVNET,
+    Commitment.FINALIZED,
+    connectTimeout = 15000,
+    readTimeout = 30000,
+)
+```
+
 Supported APIs:
 - `getAccountInfo`
 - `getBalance`

--- a/docs/README_JP.md
+++ b/docs/README_JP.md
@@ -136,6 +136,20 @@ val blockhash = connection.getLatestBlockhash()
 val finalizedBlockhash = connection.getLatestBlockhash(Commitment.FINALIZED)
 ```
 
+すべてのRPC呼び出しは接続（connect）と読み取り（read）のタイムアウトによって
+制限されるため、遅いノードや応答しないノードが呼び出しスレッドを無期限にブロック
+することはありません。デフォルトは接続15秒、読み取り30秒で、接続を作成する際に
+ミリ秒単位で上書きできます。
+
+```kotlin
+val connection = Connection(
+    RpcUrl.DEVNET,
+    Commitment.FINALIZED,
+    connectTimeout = 15000,
+    readTimeout = 30000,
+)
+```
+
 サポートされているAPI:
 - `getAccountInfo`
 - `getBalance`

--- a/docs/README_KR.md
+++ b/docs/README_KR.md
@@ -137,6 +137,19 @@ val blockhash = connection.getLatestBlockhash()
 val finalizedBlockhash = connection.getLatestBlockhash(Commitment.FINALIZED)
 ```
 
+모든 RPC 호출은 연결(connect) 및 읽기(read) 타임아웃으로 제한되므로, 느리거나
+응답하지 않는 노드가 호출 스레드를 무한정 차단할 수 없습니다. 기본값은 연결 15초,
+읽기 30초이며, 연결을 생성할 때 밀리초 단위로 재정의할 수 있습니다.
+
+```kotlin
+val connection = Connection(
+    RpcUrl.DEVNET,
+    Commitment.FINALIZED,
+    connectTimeout = 15000,
+    readTimeout = 30000,
+)
+```
+
 지원되는 API들:
 - `getAccountInfo`
 - `getBalance`

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -146,6 +146,19 @@ val blockhash = connection.getLatestBlockhash()
 val finalizedBlockhash = connection.getLatestBlockhash(Commitment.FINALIZED)
 ```
 
+每个 RPC 调用都受连接（connect）和读取（read）超时的限制，因此缓慢或无响应的节点
+不会无限期地阻塞调用线程。它们默认为连接 15 秒、读取 30 秒，并且可以在创建连接时
+以毫秒为单位进行覆盖。
+
+```kotlin
+val connection = Connection(
+    RpcUrl.DEVNET,
+    Commitment.FINALIZED,
+    connectTimeout = 15000,
+    readTimeout = 30000,
+)
+```
+
 支持的 API:
 
 - `getAccountInfo`：获取账户信息，返回指定账户的详细数据，包括余额、状态等信息。

--- a/src/main/kotlin/org/sol4k/Connection.kt
+++ b/src/main/kotlin/org/sol4k/Connection.kt
@@ -49,12 +49,21 @@ import java.util.Base64
 class Connection @JvmOverloads constructor(
     private val rpcUrl: String,
     private val commitment: Commitment = FINALIZED,
+    private val connectTimeout: Int = DEFAULT_CONNECT_TIMEOUT_MS,
+    private val readTimeout: Int = DEFAULT_READ_TIMEOUT_MS,
 ) {
     @JvmOverloads
     constructor(
         rpcUrl: RpcUrl,
         commitment: Commitment = FINALIZED,
-    ) : this(rpcUrl.value, commitment)
+        connectTimeout: Int = DEFAULT_CONNECT_TIMEOUT_MS,
+        readTimeout: Int = DEFAULT_READ_TIMEOUT_MS,
+    ) : this(rpcUrl.value, commitment, connectTimeout, readTimeout)
+
+    init {
+        require(connectTimeout >= 0) { "connectTimeout must not be negative" }
+        require(readTimeout >= 0) { "readTimeout must not be negative" }
+    }
 
     private val jsonParser = Json {
         ignoreUnknownKeys = true
@@ -318,6 +327,8 @@ class Connection @JvmOverloads constructor(
         val connection = URL(rpcUrl).openConnection() as HttpURLConnection
         connection.requestMethod = "POST"
         connection.setRequestProperty("Content-Type", "application/json")
+        connection.connectTimeout = connectTimeout
+        connection.readTimeout = readTimeout
         connection.doOutput = true
         connection.outputStream.use {
             val body = Json.encodeToString(
@@ -338,5 +349,10 @@ class Connection @JvmOverloads constructor(
             val (error) = jsonParser.decodeFromString<RpcErrorResponse>(responseBody)
             throw RpcException(error.code, error.message, responseBody)
         }
+    }
+
+    companion object {
+        const val DEFAULT_CONNECT_TIMEOUT_MS = 15_000
+        const val DEFAULT_READ_TIMEOUT_MS = 30_000
     }
 }

--- a/src/test/kotlin/org/sol4k/ConnectionTest.kt
+++ b/src/test/kotlin/org/sol4k/ConnectionTest.kt
@@ -1,0 +1,23 @@
+package org.sol4k
+
+import org.junit.jupiter.api.Test
+import java.net.ServerSocket
+import java.net.SocketTimeoutException
+import kotlin.test.assertFailsWith
+
+internal class ConnectionTest {
+
+    @Test
+    fun shouldTimeOutWhenServerNeverResponds() {
+        // A server socket that accepts connections but never writes a response,
+        // so the read blocks until readTimeout elapses.
+        ServerSocket(0).use { server ->
+            val rpcUrl = "http://127.0.0.1:${server.localPort}"
+            val connection = Connection(rpcUrl, readTimeout = 100)
+
+            assertFailsWith<SocketTimeoutException> {
+                connection.getHealth()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Every RPC call goes through `Connection.rpcCall`, which opened an `HttpURLConnection` without setting `connectTimeout` or `readTimeout`. A slow or unresponsive RPC node could therefore block the calling thread **indefinitely** — on Android this can wedge the UI thread, and on the JVM it can hang background workers with no recovery.

This change makes every RPC call time-bounded:

- Adds `connectTimeout` / `readTimeout` (milliseconds, `Int`) parameters to both `Connection` constructors, defaulting to **15s connect / 30s read** and validated as non-negative.
- Applies them in `rpcCall`.
- Existing Kotlin/Java call sites are unaffected thanks to `@JvmOverloads` and the defaults; a hung node now surfaces a `SocketTimeoutException` instead of blocking forever.

Scope is **timeouts only** — error-stream handling, retries, and async APIs are intentionally out of scope.

## Tests

- Adds the first unit test for `Connection` (`ConnectionTest`): a local `ServerSocket` that accepts but never replies, with a small `readTimeout`, asserting `getHealth()` throws `SocketTimeoutException`. No network access or external deps.
- `./gradlew ktlintCheck test` passes.

## Docs

- Documents the default timeouts and how to override them in `docs/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)