### PR TITLE
Improve RPC error handling, add transport timeouts, and fail fast on invalid signatures

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -145,6 +145,21 @@ val blockhash = connection.getLatestBlockhash()
 val finalizedBlockhash = connection.getLatestBlockhash(Commitment.FINALIZED)
 ```
 
+By default, RPC calls use a connect timeout of 15 seconds and a read timeout of
+30 seconds. You can adjust them by passing a configured `HttpUrlConnectionTransport`
+to the connection (values are in milliseconds; `0` means no timeout).
+
+```kotlin
+val transport = HttpUrlConnectionTransport(
+    connectTimeoutMillis = 5_000,
+    readTimeoutMillis = 10_000,
+)
+val connection = Connection(RpcUrl.DEVNET, transport = transport)
+```
+
+If an RPC node responds with an error, sol4k throws an `RpcException` that
+exposes the error `code`, `message`, and the `rawResponse` returned by the node.
+
 Supported APIs:
 - `getAccountInfo`
 - `getBalance`

--- a/docs/README_JP.md
+++ b/docs/README_JP.md
@@ -136,6 +136,21 @@ val blockhash = connection.getLatestBlockhash()
 val finalizedBlockhash = connection.getLatestBlockhash(Commitment.FINALIZED)
 ```
 
+デフォルトでは、RPC呼び出しは接続タイムアウト15秒、読み取りタイムアウト30秒を使用します。
+設定済みの `HttpUrlConnectionTransport` を接続に渡すことで調整できます
+（値はミリ秒単位で、`0` はタイムアウトなしを意味します）。
+
+```kotlin
+val transport = HttpUrlConnectionTransport(
+    connectTimeoutMillis = 5_000,
+    readTimeoutMillis = 10_000,
+)
+val connection = Connection(RpcUrl.DEVNET, transport = transport)
+```
+
+RPCノードがエラーを返した場合、sol4kはエラーの `code`、`message`、
+およびノードが返した `rawResponse` を含む `RpcException` をスローします。
+
 サポートされているAPI:
 - `getAccountInfo`
 - `getBalance`

--- a/docs/README_KR.md
+++ b/docs/README_KR.md
@@ -137,6 +137,21 @@ val blockhash = connection.getLatestBlockhash()
 val finalizedBlockhash = connection.getLatestBlockhash(Commitment.FINALIZED)
 ```
 
+기본적으로 RPC 호출은 15초의 연결 타임아웃과 30초의 읽기 타임아웃을 사용합니다.
+설정된 `HttpUrlConnectionTransport`를 연결에 전달하여 조정할 수 있습니다
+(값은 밀리초 단위이며 `0`은 타임아웃 없음을 의미합니다).
+
+```kotlin
+val transport = HttpUrlConnectionTransport(
+    connectTimeoutMillis = 5_000,
+    readTimeoutMillis = 10_000,
+)
+val connection = Connection(RpcUrl.DEVNET, transport = transport)
+```
+
+RPC 노드가 오류로 응답하면 sol4k는 오류 `code`, `message`, 그리고 노드가 반환한
+`rawResponse`를 노출하는 `RpcException`을 발생시킵니다.
+
 지원되는 API들:
 - `getAccountInfo`
 - `getBalance`

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -146,6 +146,21 @@ val blockhash = connection.getLatestBlockhash()
 val finalizedBlockhash = connection.getLatestBlockhash(Commitment.FINALIZED)
 ```
 
+默认情况下，RPC 调用使用 15 秒的连接超时和 30 秒的读取超时。
+您可以通过向连接传入一个配置好的 `HttpUrlConnectionTransport` 来调整
+（值以毫秒为单位，`0` 表示不设超时）。
+
+```kotlin
+val transport = HttpUrlConnectionTransport(
+    connectTimeoutMillis = 5_000,
+    readTimeoutMillis = 10_000,
+)
+val connection = Connection(RpcUrl.DEVNET, transport = transport)
+```
+
+如果 RPC 节点返回错误，sol4k 会抛出 `RpcException`，
+其中包含错误的 `code`、`message` 以及节点返回的 `rawResponse`。
+
 支持的 API:
 
 - `getAccountInfo`：获取账户信息，返回指定账户的详细数据，包括余额、状态等信息。

--- a/src/main/kotlin/org/sol4k/Connection.kt
+++ b/src/main/kotlin/org/sol4k/Connection.kt
@@ -330,8 +330,8 @@ class Connection @JvmOverloads constructor(
         } catch (_: SerializationException) {
             val (error) = try {
                 jsonParser.decodeFromString<RpcErrorResponse>(responseBody)
-            } catch (_: SerializationException) {
-                throw RpcResponseParseException(responseBody)
+            } catch (e: SerializationException) {
+                throw RpcResponseParseException(responseBody, e)
             }
             throw RpcException(error.code, error.message, responseBody)
         }

--- a/src/main/kotlin/org/sol4k/Connection.kt
+++ b/src/main/kotlin/org/sol4k/Connection.kt
@@ -22,6 +22,7 @@ import org.sol4k.api.TransactionSimulationError
 import org.sol4k.api.TransactionSimulationSuccess
 import org.sol4k.api.Version
 import org.sol4k.exception.RpcException
+import org.sol4k.exception.RpcResponseParseException
 import org.sol4k.rpc.Balance
 import org.sol4k.rpc.BlockhashResponse
 import org.sol4k.rpc.EpochInfoResult
@@ -330,13 +331,9 @@ class Connection @JvmOverloads constructor(
             val (error) = try {
                 jsonParser.decodeFromString<RpcErrorResponse>(responseBody)
             } catch (_: SerializationException) {
-                throw RpcException(UNPARSEABLE_RESPONSE_CODE, "Unable to parse the RPC node response", responseBody)
+                throw RpcResponseParseException(responseBody)
             }
             throw RpcException(error.code, error.message, responseBody)
         }
-    }
-
-    private companion object {
-        const val UNPARSEABLE_RESPONSE_CODE = -1
     }
 }

--- a/src/main/kotlin/org/sol4k/Connection.kt
+++ b/src/main/kotlin/org/sol4k/Connection.kt
@@ -327,8 +327,16 @@ class Connection @JvmOverloads constructor(
             val (result) = jsonParser.decodeFromString<RpcResponse<T>>(responseBody)
             return result
         } catch (_: SerializationException) {
-            val (error) = jsonParser.decodeFromString<RpcErrorResponse>(responseBody)
+            val (error) = try {
+                jsonParser.decodeFromString<RpcErrorResponse>(responseBody)
+            } catch (_: SerializationException) {
+                throw RpcException(UNPARSEABLE_RESPONSE_CODE, "Unable to parse the RPC node response", responseBody)
+            }
             throw RpcException(error.code, error.message, responseBody)
         }
+    }
+
+    private companion object {
+        const val UNPARSEABLE_RESPONSE_CODE = -1
     }
 }

--- a/src/main/kotlin/org/sol4k/VersionedTransaction.kt
+++ b/src/main/kotlin/org/sol4k/VersionedTransaction.kt
@@ -35,9 +35,10 @@ class VersionedTransaction private constructor(
             val a = message.accounts[i]
             if (a.verify(signature, data)) {
                 signatures[i] = Base58.encode(signature)
-                break
+                return
             }
         }
+        throw IllegalArgumentException("Signature does not match any required signer of the transaction")
     }
 
     fun serialize(): ByteArray {

--- a/src/main/kotlin/org/sol4k/exception/RpcResponseParseException.kt
+++ b/src/main/kotlin/org/sol4k/exception/RpcResponseParseException.kt
@@ -1,0 +1,7 @@
+package org.sol4k.exception
+
+import java.lang.RuntimeException
+
+data class RpcResponseParseException(
+    val rawResponse: String,
+) : RuntimeException("Unable to parse the RPC node response")

--- a/src/main/kotlin/org/sol4k/exception/RpcResponseParseException.kt
+++ b/src/main/kotlin/org/sol4k/exception/RpcResponseParseException.kt
@@ -4,4 +4,9 @@ import java.lang.RuntimeException
 
 data class RpcResponseParseException(
     val rawResponse: String,
-) : RuntimeException("Unable to parse the RPC node response")
+) : RuntimeException("Unable to parse the RPC node response") {
+
+    constructor(rawResponse: String, cause: Throwable) : this(rawResponse) {
+        initCause(cause)
+    }
+}

--- a/src/main/kotlin/org/sol4k/transport/HttpUrlConnectionTransport.kt
+++ b/src/main/kotlin/org/sol4k/transport/HttpUrlConnectionTransport.kt
@@ -39,25 +39,38 @@ class HttpUrlConnectionTransport @JvmOverloads constructor(
         }
 
         val responseCode = connection.responseCode
-        val stream: InputStream = if (responseCode < HttpURLConnection.HTTP_BAD_REQUEST) {
-            connection.inputStream
-        } else {
-            connection.errorStream
-                ?: throw IOException("RPC node returned HTTP $responseCode with an empty body")
+        if (responseCode < HttpURLConnection.HTTP_BAD_REQUEST) {
+            val responseBody = readBody(connection.inputStream)
+            connection.disconnect()
+            return responseBody
         }
 
-        val responseBody = stream.use {
-            BufferedReader(InputStreamReader(it)).use { reader ->
-                reader.readText()
-            }
-        }
-
+        val errorBody = connection.errorStream?.let { readBody(it) } ?: ""
         connection.disconnect()
-        return responseBody
+        // pass JSON bodies through so the caller can surface the RPC error;
+        // for anything else (HTML error pages, empty bodies) the HTTP status
+        // is the only meaningful signal and must not be lost
+        if (errorBody.trimStart().startsWith("{")) {
+            return errorBody
+        }
+        throw IOException(
+            if (errorBody.isEmpty()) {
+                "RPC node returned HTTP $responseCode with an empty body"
+            } else {
+                "RPC node returned HTTP $responseCode: ${errorBody.take(MAX_ERROR_BODY_IN_MESSAGE)}"
+            },
+        )
+    }
+
+    private fun readBody(stream: InputStream): String = stream.use {
+        BufferedReader(InputStreamReader(it)).use { reader ->
+            reader.readText()
+        }
     }
 
     companion object {
         const val DEFAULT_CONNECT_TIMEOUT_MILLIS = 15_000
         const val DEFAULT_READ_TIMEOUT_MILLIS = 30_000
+        private const val MAX_ERROR_BODY_IN_MESSAGE = 300
     }
 }

--- a/src/main/kotlin/org/sol4k/transport/HttpUrlConnectionTransport.kt
+++ b/src/main/kotlin/org/sol4k/transport/HttpUrlConnectionTransport.kt
@@ -1,11 +1,21 @@
 package org.sol4k.transport
 
 import java.io.BufferedReader
+import java.io.IOException
+import java.io.InputStream
 import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URL
 
-class HttpUrlConnectionTransport : RpcTransport {
+class HttpUrlConnectionTransport @JvmOverloads constructor(
+    private val connectTimeoutMillis: Int = DEFAULT_CONNECT_TIMEOUT_MILLIS,
+    private val readTimeoutMillis: Int = DEFAULT_READ_TIMEOUT_MILLIS,
+) : RpcTransport {
+
+    init {
+        require(connectTimeoutMillis >= 0) { "connectTimeoutMillis must not be negative" }
+        require(readTimeoutMillis >= 0) { "readTimeoutMillis must not be negative" }
+    }
 
     override fun post(
         url: String,
@@ -14,6 +24,8 @@ class HttpUrlConnectionTransport : RpcTransport {
     ): String {
         val connection = URL(url).openConnection() as HttpURLConnection
         connection.requestMethod = "POST"
+        connection.connectTimeout = connectTimeoutMillis
+        connection.readTimeout = readTimeoutMillis
 
         connection.setRequestProperty("Content-Type", "application/json")
         headers.forEach { (key, value) ->
@@ -26,7 +38,15 @@ class HttpUrlConnectionTransport : RpcTransport {
             it.write(body.toByteArray())
         }
 
-        val responseBody = connection.inputStream.use {
+        val responseCode = connection.responseCode
+        val stream: InputStream = if (responseCode < HttpURLConnection.HTTP_BAD_REQUEST) {
+            connection.inputStream
+        } else {
+            connection.errorStream
+                ?: throw IOException("RPC node returned HTTP $responseCode with an empty body")
+        }
+
+        val responseBody = stream.use {
             BufferedReader(InputStreamReader(it)).use { reader ->
                 reader.readText()
             }
@@ -34,5 +54,10 @@ class HttpUrlConnectionTransport : RpcTransport {
 
         connection.disconnect()
         return responseBody
+    }
+
+    companion object {
+        const val DEFAULT_CONNECT_TIMEOUT_MILLIS = 15_000
+        const val DEFAULT_READ_TIMEOUT_MILLIS = 30_000
     }
 }

--- a/src/test/kotlin/org/sol4k/ConnectionTransportTest.kt
+++ b/src/test/kotlin/org/sol4k/ConnectionTransportTest.kt
@@ -6,8 +6,10 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Test
 import org.sol4k.api.Health
+import org.sol4k.exception.RpcException
 import org.sol4k.transport.RpcTransport
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 internal class ConnectionTransportTest {
 
@@ -53,6 +55,46 @@ internal class ConnectionTransportTest {
         assertEquals(1, transport.callCount)
         assertEquals(RpcUrl.DEVNET.value, transport.url)
         assertEquals(headers, transport.headers)
+    }
+
+    @Test
+    fun shouldThrowRpcExceptionWhenNodeReturnsError() {
+        val errorBody = """{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params"},"id":1}"""
+        val connection = Connection(
+            "https://example.solana.rpc",
+            transport = StubTransport(errorBody),
+        )
+
+        val exception = assertFailsWith<RpcException> {
+            connection.getHealth()
+        }
+
+        assertEquals(-32602, exception.code)
+        assertEquals("Invalid params", exception.message)
+        assertEquals(errorBody, exception.rawResponse)
+    }
+
+    @Test
+    fun shouldThrowRpcExceptionWhenResponseIsNotJsonRpc() {
+        val htmlBody = "<html><body>502 Bad Gateway</body></html>"
+        val connection = Connection(
+            "https://example.solana.rpc",
+            transport = StubTransport(htmlBody),
+        )
+
+        val exception = assertFailsWith<RpcException> {
+            connection.getHealth()
+        }
+
+        assertEquals(htmlBody, exception.rawResponse)
+    }
+
+    private class StubTransport(private val response: String) : RpcTransport {
+        override fun post(
+            url: String,
+            body: String,
+            headers: Map<String, String>,
+        ): String = response
     }
 
     private class CapturingTransport : RpcTransport {

--- a/src/test/kotlin/org/sol4k/ConnectionTransportTest.kt
+++ b/src/test/kotlin/org/sol4k/ConnectionTransportTest.kt
@@ -11,6 +11,7 @@ import org.sol4k.exception.RpcResponseParseException
 import org.sol4k.transport.RpcTransport
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 
 internal class ConnectionTransportTest {
 
@@ -88,6 +89,7 @@ internal class ConnectionTransportTest {
         }
 
         assertEquals(htmlBody, exception.rawResponse)
+        assertNotNull(exception.cause)
     }
 
     private class StubTransport(private val response: String) : RpcTransport {

--- a/src/test/kotlin/org/sol4k/ConnectionTransportTest.kt
+++ b/src/test/kotlin/org/sol4k/ConnectionTransportTest.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Test
 import org.sol4k.api.Health
 import org.sol4k.exception.RpcException
+import org.sol4k.exception.RpcResponseParseException
 import org.sol4k.transport.RpcTransport
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -75,14 +76,14 @@ internal class ConnectionTransportTest {
     }
 
     @Test
-    fun shouldThrowRpcExceptionWhenResponseIsNotJsonRpc() {
+    fun shouldThrowParseExceptionWhenResponseIsNotJsonRpc() {
         val htmlBody = "<html><body>502 Bad Gateway</body></html>"
         val connection = Connection(
             "https://example.solana.rpc",
             transport = StubTransport(htmlBody),
         )
 
-        val exception = assertFailsWith<RpcException> {
+        val exception = assertFailsWith<RpcResponseParseException> {
             connection.getHealth()
         }
 

--- a/src/test/kotlin/org/sol4k/VersionedTransactionTest.kt
+++ b/src/test/kotlin/org/sol4k/VersionedTransactionTest.kt
@@ -6,6 +6,7 @@ import java.math.BigDecimal
 import java.nio.ByteBuffer
 import java.util.Base64
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class VersionedTransactionTest {
@@ -129,5 +130,34 @@ class VersionedTransactionTest {
         transaction2.sign(signer2)
 
         assertTrue(transaction1.serialize().contentEquals(transaction2.serialize()))
+    }
+
+    @Test
+    fun shouldRejectSignatureThatDoesNotMatchAnySigner() {
+        val signer = Keypair.generate()
+        val nonSigner = Keypair.generate()
+        val blockhash = "GYQReb5N3KWsM7x7aboAGTb6kQSxDGRZ1S42N6RTNkgS"
+        val instruction = BaseInstruction(
+            ByteBuffer.allocate(8).array(),
+            listOf(AccountMeta.writable(Keypair.generate().publicKey)),
+            Keypair.generate().publicKey,
+        )
+        val message = TransactionMessage.newMessage(signer.publicKey, blockhash, instruction)
+        val transaction = VersionedTransaction(message)
+
+        // a keypair that is not a required signer of the transaction
+        assertFailsWith<IllegalArgumentException> {
+            transaction.sign(nonSigner)
+        }
+
+        // a signature produced over different data
+        val signatureOfWrongData = Base58.encode(signer.sign("unrelated data".toByteArray()))
+        assertFailsWith<IllegalArgumentException> {
+            transaction.addSignature(signatureOfWrongData)
+        }
+
+        // a valid signature is still accepted
+        transaction.sign(signer)
+        assertEquals(1, transaction.signatures.filterNotNull().size)
     }
 }

--- a/src/test/kotlin/org/sol4k/transport/HttpUrlConnectionTransportTest.kt
+++ b/src/test/kotlin/org/sol4k/transport/HttpUrlConnectionTransportTest.kt
@@ -1,0 +1,66 @@
+package org.sol4k.transport
+
+import com.sun.net.httpserver.HttpServer
+import org.junit.jupiter.api.Test
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.SocketTimeoutException
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+internal class HttpUrlConnectionTransportTest {
+
+    @Test
+    fun shouldTimeOutWhenServerNeverResponds() {
+        ServerSocket(0).use { server ->
+            val transport = HttpUrlConnectionTransport(
+                connectTimeoutMillis = 1_000,
+                readTimeoutMillis = 250,
+            )
+
+            assertFailsWith<SocketTimeoutException> {
+                transport.post(
+                    "http://localhost:${server.localPort}",
+                    """{"method":"getHealth"}""",
+                    emptyMap(),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun shouldReturnErrorBodyOnHttpErrorStatus() {
+        val errorBody = """{"jsonrpc":"2.0","error":{"code":429,"message":"Too many requests"},"id":1}"""
+        val server = HttpServer.create(InetSocketAddress(0), 0)
+        server.createContext("/") { exchange ->
+            exchange.requestBody.use { it.readBytes() }
+            val bytes = errorBody.toByteArray()
+            exchange.sendResponseHeaders(429, bytes.size.toLong())
+            exchange.responseBody.use { it.write(bytes) }
+        }
+        server.start()
+        try {
+            val transport = HttpUrlConnectionTransport()
+
+            val response = transport.post(
+                "http://localhost:${server.address.port}/",
+                """{"method":"getHealth"}""",
+                emptyMap(),
+            )
+
+            assertEquals(errorBody, response)
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun shouldRejectNegativeTimeouts() {
+        assertFailsWith<IllegalArgumentException> {
+            HttpUrlConnectionTransport(connectTimeoutMillis = -1)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            HttpUrlConnectionTransport(readTimeoutMillis = -1)
+        }
+    }
+}

--- a/src/test/kotlin/org/sol4k/transport/HttpUrlConnectionTransportTest.kt
+++ b/src/test/kotlin/org/sol4k/transport/HttpUrlConnectionTransportTest.kt
@@ -2,11 +2,13 @@ package org.sol4k.transport
 
 import com.sun.net.httpserver.HttpServer
 import org.junit.jupiter.api.Test
+import java.io.IOException
 import java.net.InetSocketAddress
 import java.net.ServerSocket
 import java.net.SocketTimeoutException
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 internal class HttpUrlConnectionTransportTest {
 
@@ -49,6 +51,35 @@ internal class HttpUrlConnectionTransportTest {
             )
 
             assertEquals(errorBody, response)
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun shouldReportHttpStatusWhenErrorBodyIsNotJson() {
+        val errorBody = "<html><body>502 Bad Gateway</body></html>"
+        val server = HttpServer.create(InetSocketAddress(0), 0)
+        server.createContext("/") { exchange ->
+            exchange.requestBody.use { it.readBytes() }
+            val bytes = errorBody.toByteArray()
+            exchange.sendResponseHeaders(502, bytes.size.toLong())
+            exchange.responseBody.use { it.write(bytes) }
+        }
+        server.start()
+        try {
+            val transport = HttpUrlConnectionTransport()
+
+            val exception = assertFailsWith<IOException> {
+                transport.post(
+                    "http://localhost:${server.address.port}/",
+                    """{"method":"getHealth"}""",
+                    emptyMap(),
+                )
+            }
+
+            assertTrue(exception.message!!.contains("502"))
+            assertTrue(exception.message!!.contains(errorBody))
         } finally {
             server.stop(0)
         }


### PR DESCRIPTION
## Summary

This PR fixes three failure-behavior issues in one pass. Supersedes #203, which added timeouts directly to `Connection` before the transport layer was extracted in #197.

### 1. RPC error bodies are no longer lost on HTTP error statuses

`HttpUrlConnectionTransport` read only `connection.inputStream`, which throws a bare `IOException` on any non-2xx status. Public RPC endpoints routinely answer with 429 (and providers with 4xx/5xx) carrying a JSON-RPC error body — that body sat unread in `errorStream`, so users saw `Server returned HTTP response code: 429` with no detail. The transport now reads the error stream on HTTP >= 400 and, when the body is JSON-shaped, returns it so `Connection` surfaces it as a proper `RpcException` with `code`, `message`, and `rawResponse`. Non-JSON or empty error bodies (e.g. HTML error pages from proxies) throw an `IOException` naming the HTTP status with a truncated body snippet, so the status code is never lost.

As part of the same error path, `Connection.rpcCall` now throws a dedicated `RpcResponseParseException` carrying the raw body when a response is neither a result nor a JSON-RPC error (e.g. HTML from a proxy), instead of leaking a confusing kotlinx `SerializationException`; the original exception is chained as the cause to keep field-level decode failures diagnosable. A separate exception type is used because such responses have no JSON-RPC error code, and inventing one for `RpcException` would be indistinguishable from a server-defined code.

### 2. RPC calls are now time-bounded

`HttpURLConnection` defaults to infinite connect/read timeouts, so a hung node could block the calling thread forever (on Android, potentially the UI thread). `HttpUrlConnectionTransport` now applies **15s connect / 30s read** timeouts by default, configurable via its constructor (`@JvmOverloads`, values validated as non-negative, `0` = no timeout):

```kotlin
val transport = HttpUrlConnectionTransport(connectTimeoutMillis = 5_000, readTimeoutMillis = 10_000)
val connection = Connection(RpcUrl.DEVNET, transport = transport)
```

Timeouts live on the transport (not `Connection`) so they don't leak into custom `RpcTransport` implementations.

### 3. `VersionedTransaction` no longer silently drops invalid signatures

`sign`/`addSignature` looped over required signers and, if the signature verified against none of them (wrong keypair, signature over different data), did nothing. The failure only surfaced later as a misleading `"Signature verification failed"` from `serialize()`. Both methods now throw `IllegalArgumentException("Signature does not match any required signer of the transaction")` at the point of the mistake.

## Tests

New coverage (all passing, `./gradlew ktlintCheck test`):

- `HttpUrlConnectionTransportTest`: read timeout fires as `SocketTimeoutException` (local `ServerSocket` that never responds); a 429 JSON body is returned intact and a 502 HTML body throws an `IOException` naming the status (local `com.sun.net.httpserver.HttpServer`); negative timeouts are rejected.
- `ConnectionTransportTest`: a JSON-RPC error body becomes `RpcException` with the right `code`/`message`/`rawResponse`; an HTML body becomes `RpcResponseParseException` with the raw body attached.
- `VersionedTransactionTest`: signing with a non-signer keypair and adding a signature over wrong data both throw; a valid signature is still accepted afterwards.

## Docs

Documented the default timeouts, how to override them, and the `RpcException` behavior in `docs/README.md` and the JP/KR/ZH translations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

