### PR TITLE
feat: include any logs in simulation failure exception

### DIFF
--- a/src/main/kotlin/org/sol4k/Connection.kt
+++ b/src/main/kotlin/org/sol4k/Connection.kt
@@ -240,8 +240,8 @@ class Connection @JvmOverloads constructor(
         val (err, logs) = result.value
         if (err != null) {
             return when (err) {
-                is JsonPrimitive -> TransactionSimulationError(err.content)
-                else -> TransactionSimulationError(err.toString())
+                is JsonPrimitive -> TransactionSimulationError(err.content, logs)
+                else -> TransactionSimulationError(err.toString(), logs)
             }
         } else if (logs != null) {
             return TransactionSimulationSuccess(logs)

--- a/src/main/kotlin/org/sol4k/api/TransactionSimulation.kt
+++ b/src/main/kotlin/org/sol4k/api/TransactionSimulation.kt
@@ -2,6 +2,6 @@ package org.sol4k.api
 
 sealed class TransactionSimulation
 
-class TransactionSimulationError(val error: String) : TransactionSimulation()
+class TransactionSimulationError(val error: String, val logs: List<String>?) : TransactionSimulation()
 
 class TransactionSimulationSuccess(val logs: List<String>) : TransactionSimulation()


### PR DESCRIPTION
When we experience any failures when simulating transactions while using this library, the exception thrown contains minimal information about what went wrong, e.g., 

```
Transaction simulation failed: Error processing Instruction 0: custom program error: 0x1
```

In these cases, there should be logs which could possibly give more information about the reason the tx failed.

`logs` _might_ be null, if the transaction failed before it was executed, but any failure during transaction execution should include _some_ logs. 

It would be useful to surface these logs, if any, to the library user. 

integration tests pass, I topped up the sol in the default account. 