### PR TITLE
Update build dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm' version '2.4.0'
-    id 'org.jetbrains.dokka' version '2.1.0'
-    id 'com.vanniktech.maven.publish' version '0.35.0'
-    id 'org.jetbrains.kotlin.plugin.serialization' version '2.4.0'
-    id 'org.jlleitschuh.gradle.ktlint' version '14.0.1'
+    id 'org.jetbrains.kotlin.jvm' version '2.4.10'
+    id 'org.jetbrains.dokka' version '2.2.0'
+    id 'com.vanniktech.maven.publish' version '0.37.0'
+    id 'org.jetbrains.kotlin.plugin.serialization' version '2.4.10'
+    id 'org.jlleitschuh.gradle.ktlint' version '14.2.0'
 }
 
 group = 'org.sol4k'
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0'
     implementation 'org.sol4k:tweetnacl:0.1.6'
     implementation 'org.sol4k:utilities:0.1.0'
 


### PR DESCRIPTION
## Summary

Updates all build dependencies and plugins to their latest stable versions:

| Dependency / plugin | Before | After |
|---|---|---|
| Kotlin (`kotlin.jvm` + `plugin.serialization`) | 2.4.0 | 2.4.10 |
| kotlinx-serialization-json | 1.10.0 | 1.11.0 |
| Dokka | 2.1.0 | 2.2.0 |
| vanniktech maven-publish | 0.35.0 | 0.37.0 |
| ktlint-gradle | 14.0.1 | 14.2.0 |

`org.sol4k:tweetnacl` (0.1.6), `org.sol4k:utilities` (0.1.0), and the Gradle wrapper (9.6.1) are already at their latest versions. Pre-release versions (e.g. Kotlin 2.4.20-Beta1) were skipped.

No code changes were needed. Two pre-existing compiler warnings (language version 2.0 deprecation, `TransactionMessage` `copy()` visibility) are unrelated to these bumps and left for a separate change.

## Testing

Ran everything CI runs, locally:

- `./gradlew build` — passes (unit tests + ktlint included)
- `./gradlew ktlintCheck` — passes
- `./gradlew integrationTest` — passes against Devnet
- `./gradlew publishToMavenLocal` — passes (exercises the updated Dokka and maven-publish plugins used by the release workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)